### PR TITLE
Support MC 1.13+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,9 @@ build/
 in/
 out/
 .idea
-
+.gradle
 *.iml
+.project
+.settings
+.classpath
+

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ jar {
 dependencies {
     compile group: 'com.google.code.gson', name: 'gson', version: '2.2.4'
     compile group: 'com.mojang', name: 'authlib', version: '1.5.16'
-    compile group: 'io.netty', name: 'netty-all', version: '4.0.10.Final'
+    compile group: 'io.netty', name: 'netty-all', version: '4.1.13.Final'
     compile group: 'org.ow2.asm', name: 'asm-debug-all', version: '5.0.2'
     compile group: 'com.google.guava', name: 'guava', version: '17.0'
     testCompile group: 'junit', name: 'junit', version: '4.11'

--- a/src/main/java/uk/co/thinkofdeath/vanillacord/Main.java
+++ b/src/main/java/uk/co/thinkofdeath/vanillacord/Main.java
@@ -21,26 +21,15 @@ public class Main {
 
     public static void main(String[] args) throws IOException {
         if (args.length != 1) {
-            System.out.println("Args: <version>");
+            System.out.println("Args: <server file>");
             return;
         }
 
-        String version = args[0];
-
-        String url = String.format("http://s3.amazonaws.com/Minecraft.Download/versions/%1$s/minecraft_server.%1$s.jar", version);
-
-        File in = new File("in/" + version + ".jar");
-        in.getParentFile().mkdirs();
-        if (!in.exists()) {
-            System.out.println("Downloading");
-            try (FileOutputStream fin = new FileOutputStream(in)) {
-                Resources.copy(new URL(url), fin);
-            }
-        }
+        String filename = args[0];
+        File in = new File(filename);
         addURL(in.toURI().toURL());
 
-        File out = new File("out/" + version + "-bungee.jar");
-        out.getParentFile().mkdirs();
+        File out = new File(in.getName().replace(".jar","")+"-bungee.jar");
         if (out.exists()) out.delete();
 
         try (ZipInputStream zip = new ZipInputStream(new FileInputStream(in));

--- a/src/main/java/uk/co/thinkofdeath/vanillacord/TypeChecker.java
+++ b/src/main/java/uk/co/thinkofdeath/vanillacord/TypeChecker.java
@@ -21,7 +21,7 @@ public class TypeChecker extends ClassVisitor {
 
             @Override
             public void visitLdcInsn(Object cst) {
-                if (cst instanceof String && ((String) cst).startsWith("Outdated client! Please use")) {
+                if (cst instanceof String && ((String) cst).startsWith("multiplayer.disconnect.outdated_server")) {
                     handshakeListener = true;
                     hsName = name;
                     hsDesc = desc;

--- a/src/main/java/uk/co/thinkofdeath/vanillacord/util/BungeeHelper.java
+++ b/src/main/java/uk/co/thinkofdeath/vanillacord/util/BungeeHelper.java
@@ -14,8 +14,8 @@ import java.util.UUID;
 public class BungeeHelper {
 
     private static final Gson gson = new Gson();
-    public static AttributeKey<UUID> UUID_KEY = new AttributeKey<>("spoofed-uuid");
-    public static AttributeKey<Property[]> PROPERTIES_KEY = new AttributeKey<>("spoofed-props");
+    public static AttributeKey<UUID> UUID_KEY = AttributeKey.valueOf("spoofed-uuid");
+    public static AttributeKey<Property[]> PROPERTIES_KEY = AttributeKey.valueOf("spoofed-props");
 
     public static void parseHandshake(Object networkManager, Object handshake) {
         try {


### PR DESCRIPTION
I removed the auto-downloading feature of the MC server jar since the naming has changed form MC 1.12 to 1.13. Instead you now must run vanillacord on an existing local server jar.

Usage:
```bash
java -jar vanillacord.jar <filename>
```

For example, to setup a bungee-enabled minecraft server for version 1.13, do this:
```bash
wget https://launcher.mojang.com/mc/game/1.13/server/d0caafb8438ebd206f99930cfaecfa6c9a13dca0/server.jar
java -jar vanillacord.jar server.jar
```
After that you can start the patched Minecraft server like this:
```bash
java -jar server-bungee.jar
```

